### PR TITLE
Add facets manually

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -61,4 +61,11 @@ Use the ``Stl`` class provided.
             vertex['y']
             vertex['z']
 
+    # add another set of facets
+    # every face is a tuple: (vertices, normal)
+    stl.add_facets([
+        (((0, 0, 0), (0, 1, 0), (0, 0, 1)), (1, 0, 0)),
+        (((0, 0, 0), (1, 0, 0), (0, 0, 1)), (0, 1, 0)),
+    ])
+
 Note that all C ADMesh functions start with ``stl_`` prefix and the Python methods of this module do not. Also note that not all C ADMesh functions are provided, because some would require more complicated approach and are not considered worthy. In case you are missing some functions, create `new issue <https://github.com/admesh/python-admesh/issues/new>`_.

--- a/_admesh.pyx
+++ b/_admesh.pyx
@@ -18,6 +18,9 @@ cdef class Stl(object):
             self._open(path)
         else:
             stl_initialize(&self._c_stl_file)
+            if stl_get_error(&self._c_stl_file):
+                stl_clear_error(&self._c_stl_file)
+                raise AdmeshError('stl_initialize')
             self._c_stl_file.stats.type = Stl.INMEMORY
 
     property stats:

--- a/_admesh.pyx
+++ b/_admesh.pyx
@@ -58,6 +58,10 @@ cdef class Stl(object):
         """
         Add one or more facets
 
+        every facet is a tuple of two elements:
+            * vertices: tuple of three points (each a tuple of three floats)
+            * normal: tuple of three floats
+
         Example usage:
             stl_object.add_facets([
                 (((0, 0, 0), (1, 0, 0), (0, 1, 0)), (1, 0, 0)),

--- a/_admesh.pyx
+++ b/_admesh.pyx
@@ -71,6 +71,11 @@ cdef class Stl(object):
         current_facet_index = self._c_stl_file.stats.number_of_facets
         self._c_stl_file.stats.number_of_facets += len(facets)
         stl_reallocate(&self._c_stl_file)
+        if stl_get_error(&self._c_stl_file):
+            # reset the facet count back to the original size
+            self._c_stl_file.stats.number_of_facets = current_facet_index
+            stl_clear_error(&self._c_stl_file)
+            raise AdmeshError('stl_reallocate')
         for facet in facets:
             facet_struct.vertex = [{"x": x, "y": y, "z": z}
                                    for (x, y, z) in facet[0]]

--- a/_admesh.pyx
+++ b/_admesh.pyx
@@ -71,6 +71,7 @@ cdef class Stl(object):
         stl_reallocate(&self._c_stl_file)
         for facet in facets:
             self._c_stl_file.facet_start[current_facet_index] = facet
+            stl_facet_stats(&self._c_stl_file, self._c_stl_file.facet_start[current_facet_index], False);
             current_facet_index += 1
 
     def repair(self,

--- a/test/test_object.py
+++ b/test/test_object.py
@@ -17,6 +17,12 @@ class TestObjectCapabilities(object):
         assert len(facets[0]['vertex']) == 3
         assert facets[0]['vertex'][0]['x'] == 0
 
+    def test_add_facets(self):
+        stl = Stl('test/block.stl')
+        facet_count = len(stl)
+        stl.add_facets([(((0, 0, 0), (1, 1, 1), (1, 0, 0)), (1, 0, 0))])
+        assert len(stl) == facet_count + 1
+
     def test_str(self):
         '''Tests the output of str'''
         stl = Stl('test/block.stl')

--- a/test/test_stats.py
+++ b/test/test_stats.py
@@ -25,6 +25,13 @@ class TestStats(object):
         stl = Stl('test/block.stl')
         assert stl.stats['header'] == 'solid  admesh'.encode('UTF-8')
 
+    def test_add_facets_updates_stats(self):
+        '''Tests if adding new facets updates the mesh stats'''
+        stl = Stl('test/block.stl')
+        max_x = stl.stats['max']['x']
+        stl.add_facets([(((0, 0, 0), (1, 1, 1), (max_x + 1, 0, 0)), (1, 0, 0))])
+        assert max_x + 1 == stl.stats['max']['x']
+
     def test_write_to_stats(self):
         '''Test if writing to stats raises exception'''
         stl = Stl()


### PR DESCRIPTION
This is a follow-up on #12 (I am missing push permissions for that branch).

I changed the parameter format for "add_facets" to tuples (instead of dicts). If you think, that dicts are more suitable, I can revert this.

If you think, that this 'add_facets' method will be superseded in the near future by another (more efficient) implementation with a different interface, then maybe it should have a different name, reflecting its input parameters (e.g. 'add_facets_from_tuples').